### PR TITLE
Feature/session

### DIFF
--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -100,6 +100,11 @@ class InteractiveOMC(
         self.socket.close()
         self.process.terminate()
 
+    def __enter__(
+        self
+    ):
+        return self
+
     def __exit__(
         self,
         exc_type,

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -1,7 +1,11 @@
 
 from pathlib import Path
+import os
+import subprocess
 import tempfile
 import typing
+import uuid
+import zmq
 
 
 def find_openmodelica_zmq_port_filepath(
@@ -27,3 +31,80 @@ def find_openmodelica_zmq_port_filepath(
         )
 
     return candidates[0]
+
+
+class InteractiveOMC(
+    typing.NamedTuple
+):
+    socket: zmq.Socket
+    process: subprocess.Popen
+
+    @classmethod
+    def open(
+        cls,
+        omc_executable: typing.Optional[os.PathLike] = None,
+    ) -> "InteractiveOMC":
+        executable: str
+        if omc_executable is None:
+            executable = "omc"
+        else:
+            executable = os.fspath(omc_executable)
+
+        suffix = str(uuid.uuid4())
+
+        socket = zmq.Context().socket(
+            # pylint: disable=no-member
+            zmq.REQ
+        )
+
+        process = subprocess.Popen(
+            [executable, "--interactive=zmq", f"-z={suffix}"],
+            universal_newlines=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+
+        self = cls(
+            socket=socket,
+            process=process,
+        )
+
+        try:
+            self.__connect_socket(suffix)
+        except Exception:
+            self.close()
+            raise
+
+        return self
+
+    def __connect_socket(
+        self,
+        suffix: str
+    ):
+        process_stdout: typing.IO
+        if self.process.stdout is None:
+            ValueError(
+                "Ensure that subprocee.Popen(stdout=subprocess.PIPE)"
+            )
+        else:
+            process_stdout = self.process.stdout
+
+        process_stdout.readline()
+        port = find_openmodelica_zmq_port_filepath(suffix).read_text()
+
+        self.socket.connect(port)
+
+    def close(
+        self
+    ) -> None:
+        self.socket.close()
+        self.process.terminate()
+
+    def __exit__(
+        self,
+        exc_type,
+        exc_value,
+        traceback,
+    ):
+        self.close()
+        return False

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -1,0 +1,29 @@
+
+from pathlib import Path
+import tempfile
+import typing
+
+
+def find_openmodelica_zmq_port_filepath(
+    suffix: typing.Optional[str]
+) -> Path:
+    temp_dir = Path(tempfile.gettempdir())
+
+    pattern_of_name = "openmodelica*.port"
+    if suffix is not None:
+        pattern_of_name += f".{suffix}"
+
+    candidates = tuple(temp_dir.glob(pattern_of_name))
+
+    if not candidates:
+        raise ValueError(
+            f"Can't find openmodelica port file "
+            f"at {temp_dir}"
+        )
+    elif len(candidates) >= 2:
+        raise ValueError(
+            f"Ambiguous openmodelica port file {candidates}"
+            f"at {temp_dir}"
+        )
+
+    return candidates[0]

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -108,3 +108,10 @@ class InteractiveOMC(
     ):
         self.close()
         return False
+
+    def execute(
+        self,
+        expression: str
+    ) -> str:
+        self.socket.send_string(expression)
+        return self.socket.recv_string()

--- a/omc4py/session/__main__.py
+++ b/omc4py/session/__main__.py
@@ -1,0 +1,38 @@
+
+import cmd
+
+from . import InteractiveOMC
+
+
+class OMCShell(
+    cmd.Cmd,
+):
+    omc: InteractiveOMC
+
+    prompt = "|omc| >>> "
+
+    def __init__(
+        self,
+        *args,
+        omc: InteractiveOMC,
+        **kwrds,
+    ):
+        super(OMCShell, self).__init__(*args, **kwrds)
+
+        self.omc = omc
+
+    def do_shell(self, arg):
+        print(self.omc.execute(arg), end="")
+
+    def do_quit(self, arg):
+        return True
+
+
+def main():
+    with InteractiveOMC.open() as omc:
+        OMCShell(
+            omc=omc
+        ).cmdloop()
+
+
+main()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         "ModelicaLanguage==0.0.0a6",  # fix to current alpha version
         "OMPython",
+        "PyZMQ",
         "Arpeggio",
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
Add very simple class for OMC interactive session `omc4py.session.InteractiveOMC`

```python3
from omc4py.session import InteractiveOMC

with InteractiveOMC.open("/usr/bin/omc") as omc:
    version = omc.execute("getVersion()")
    print(version)
```

`omc4py.session` package also provide command line interface by `cmd` (Python stdlib)

```bash
$ python3 -m omc4py.session
|omc| >>> !getVersion()
"OpenModelica 1.16.0~dev-557-g9deb50c"
|omc| >>> quit
```