### PR TITLE
Refactor/omc session

### DIFF
--- a/omc4py/session/__main__.py
+++ b/omc4py/session/__main__.py
@@ -1,4 +1,5 @@
 
+import argparse
 import cmd
 
 from . import InteractiveOMC
@@ -29,7 +30,17 @@ class OMCShell(
 
 
 def main():
-    with InteractiveOMC.open() as omc:
+    parser = argparse.ArgumentParser(
+        prog="OMCSessionDebug"
+    )
+    parser.add_argument(
+        "--omc",
+        help="omc executable",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    with InteractiveOMC.open(omc_command=args.omc) as omc:
         OMCShell(
             omc=omc
         ).cmdloop()


### PR DESCRIPTION
Add `--omc` option to select omc executable from command-line

See `python3 -m omc4py.session --help`