### PR TITLE
Refactor/omc process

### DIFF
--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -1,5 +1,6 @@
 
 import arpeggio  # type: ignore
+import atexit
 import numpy
 import os
 from pathlib import Path
@@ -219,6 +220,9 @@ class InteractiveOMC(
             return exception.OMCError(error_message)
         else:
             return exception.OMCWarning(error_message)
+
+
+atexit.register(InteractiveOMC.close_all)
 
 
 def parse_omc_value(

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -167,6 +167,13 @@ class InteractiveOMC(
             self.process.terminate()
             self.__instances.remove(self)
 
+    @classmethod
+    def close_all(
+        cls,
+    ) -> None:
+        for self in cls.__instances.copy():
+            self.close()
+
     def __enter__(
         self
     ):

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -87,7 +87,7 @@ class InteractiveOMC(
 
         process = subprocess.Popen(
             [
-                resolve_command(omc_command),
+                str(resolve_command(omc_command)),
                 "--interactive=zmq", f"-z={suffix}"
             ],
             universal_newlines=True,

--- a/omc4py/session/__init__.py
+++ b/omc4py/session/__init__.py
@@ -65,10 +65,31 @@ omc_error_pattern = re.compile(
 
 
 class InteractiveOMC(
-    typing.NamedTuple
 ):
-    socket: zmq.Socket
-    process: subprocess.Popen
+    __slots__ = (
+        "__socket",
+        "__process",
+    )
+
+    __socket: zmq.Socket
+    __process: subprocess.Popen
+
+    def __new__(
+        cls,
+        socket: zmq.Socket,
+        process: subprocess.Popen,
+    ):
+        self = super().__new__(cls)
+        self.__socket = socket
+        self.__process = process
+
+        return self
+
+    @property
+    def socket(self) -> zmq.Socket: return self.__socket
+
+    @property
+    def process(self) -> subprocess.Popen: return self.__process
 
     @classmethod
     def open(


### PR DESCRIPTION
# `omc4py.session.InteractiveOMC` update

- Fix Popen argument mistake (ensure all commands are `str`)
- auto-close at exit time (Implemented by `atexit`)