### PR TITLE
Refactor/variable name and type name

### DIFF
--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -202,6 +202,5 @@ class TypeName(
 
 from omc4py.session import (  # noqa: E402
     parser,
-    string,
     visitor,
 )

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -72,16 +72,10 @@ class VariableName(
                 f"Invalid modelica identifier, got {obj_str!r}"
             )
 
-        return cls._from_str_no_check(obj_str)
-
-    @classmethod
-    def _from_str_no_check(
-        cls,
-        variableName: str,
-    ) -> "VariableName":
-        self = super().__new__(cls)
-        self.__str = variableName
-        return self
+        return _VariableName_from_valid_identifier_no_check(
+            cls,
+            obj_str
+        )
 
     def __eq__(
         self, other,

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -124,6 +124,9 @@ class TypeName(
         return tuple(map(str, self.__parts))
 
     @property
+    def is_absolute(self) -> bool: return str(self.parts[0]) == "."
+
+    @property
     def last_identifier(
         self,
     ) -> VariableName:

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -186,9 +186,10 @@ class TypeName(
     def __str__(
         self,
     ) -> str:
-        return ".".join(
-            map(string.to_omc_literal, self.parts)
-        )
+        if self.is_absolute:
+            return "." + ".".join(self.parts[1:])
+        else:
+            return ".".join(self.parts)
 
     __to_omc_literal__ = __str__
 

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -101,6 +101,15 @@ class VariableName(
         self.__str = obj_str
         return self
 
+    @classmethod
+    def _from_str_no_check(
+        cls,
+        variableName: str,
+    ) -> "VariableName":
+        self = super().__new__(cls)
+        self.__str = variableName
+        return self
+
     def __eq__(
         self, other,
     ):

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -44,15 +44,6 @@ def split_type_specifier(
         raise ValueError(f"Invalid type_specifier, got {type_specifier!r}")
 
 
-def _VariableName_from_valid_identifier_no_check(
-    cls: typing.Type["VariableName"],
-    identifier: str,
-):
-    variableName = object.__new__(VariableName)
-    variableName._VariableName__str = identifier
-    return variableName
-
-
 class VariableName(
 ):
     __slots__ = "__str"
@@ -113,20 +104,17 @@ class TypeName(
     __parts: typing.Tuple[str, ...]
 
     def __new__(cls, *parts):
-        return cls._from_parts_no_check(
+        if len(parts) == 1:
+            part, = parts
+            if isinstance(part, TypeName):
+                return part
+
+        return _TypeName_from_valid_parts_no_check(
+            cls,
             cls.__checked_parts(
                 parts
             )
         )
-
-    @classmethod
-    def _from_parts_no_check(
-        cls,
-        parts: typing.Iterable[str]
-    ) -> "TypeName":
-        self = super().__new__(cls)
-        self.__parts = tuple(parts)
-        return self
 
     @property
     def parts(
@@ -148,8 +136,9 @@ class TypeName(
         self,
     ) -> typing.Iterator["TypeName"]:
         for end in reversed(range(1, len(self.parts))):
-            yield type(self)._from_parts_no_check(
-                self.parts[:end]
+            yield _TypeName_from_valid_parts_no_check(
+                type(self),
+                self.parts[:end],
             )
 
     @property
@@ -214,6 +203,24 @@ class TypeName(
         other: typing.Union[str, VariableName, "TypeName"]
     ):
         return type(self)(self, other)
+
+
+def _VariableName_from_valid_identifier_no_check(
+    cls: typing.Type["VariableName"],
+    identifier: str,
+):
+    variableName = object.__new__(VariableName)
+    variableName._VariableName__str = identifier
+    return variableName
+
+
+def _TypeName_from_valid_parts_no_check(
+    cls: typing.Type["TypeName"],
+    parts: typing.Iterable[str],
+):
+    typeName = object.__new__(TypeName)
+    typeName._TypeName__parts = tuple(parts)
+    return typeName
 
 
 from omc4py.session import (  # noqa: E402

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -123,7 +123,7 @@ class TypeName(
         parts: typing.Iterable[str]
     ) -> "TypeName":
         self = super().__new__(cls)
-        self.__parts = parts
+        self.__parts = tuple(parts)
         return self
 
     @property

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -13,11 +13,6 @@ import functools
 import numpy  # type: ignore
 import typing
 
-from omc4py.session import (
-    parser,
-    string,
-)
-
 
 Real = numpy.double
 Integer = numpy.intc
@@ -230,3 +225,9 @@ class TypeName(
         other: typing.Union[str, VariableName, "TypeName"]
     ):
         return type(self)(self, other)
+
+
+from omc4py.session import (  # noqa: E402
+    parser,
+    string,
+)

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -182,21 +182,6 @@ class TypeName(
                 )
             yield part
 
-    @staticmethod
-    def to_variableNames(
-        name: typing.Union[str, VariableName, "TypeName"]
-    ) -> typing.Tuple[str, ...]:
-        if isinstance(name, str):
-            return tuple(
-                split_type_specifier(name)
-            )
-        elif isinstance(name, VariableName):
-            return str(name),
-        elif isinstance(name, TypeName):
-            return name.parts
-        else:
-            raise TypeError()
-
     def __hash__(self):
         return hash(self.parts)
 

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -109,6 +109,14 @@ class TypeName(
 
     __parts: typing.Tuple[VariableName, ...]
 
+    def __new__(cls, *parts):
+        self = object.__new__(cls)
+        self.__parts = sum(
+            map(cls.to_variableNames, parts),
+            (),
+        )
+        return self
+
     @property
     def parts(
         self,
@@ -157,14 +165,6 @@ class TypeName(
             return name.parts
         else:
             raise TypeError()
-
-    def __new__(cls, *parts):
-        self = object.__new__(cls)
-        self.__parts = sum(
-            map(cls.to_variableNames, parts),
-            (),
-        )
-        return self
 
     def __hash__(self):
         return hash(self.parts)

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -110,12 +110,12 @@ class TypeName(
     __parts: typing.Tuple[str, ...]
 
     def __new__(cls, *parts):
-        self = object.__new__(cls)
-        self.__parts = sum(
-            map(cls.to_variableNames, parts),
-            (),
+        return cls._from_parts_no_check(
+            sum(
+                map(cls.to_variableNames, parts),
+                (),
+            )
         )
-        return self
 
     @classmethod
     def _from_parts_no_check(

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -107,7 +107,7 @@ class TypeName(
         "__parts",
     )
 
-    __parts: typing.Tuple[VariableName, ...]
+    __parts: typing.Tuple[str, ...]
 
     def __new__(cls, *parts):
         self = object.__new__(cls)
@@ -121,7 +121,7 @@ class TypeName(
     def parts(
         self,
     ) -> typing.Tuple[str, ...]:
-        return tuple(map(str, self.__parts))
+        return self.__parts
 
     @property
     def is_absolute(self) -> bool: return str(self.parts[0]) == "."
@@ -157,13 +157,13 @@ class TypeName(
     @staticmethod
     def to_variableNames(
         name: typing.Union[str, VariableName, "TypeName"]
-    ) -> typing.Tuple[VariableName, ...]:
+    ) -> typing.Tuple[str, ...]:
         if isinstance(name, str):
             return tuple(
-                map(VariableName, split_type_specifier(name))
+                split_type_specifier(name)
             )
         elif isinstance(name, VariableName):
-            return name,
+            return str(name),
         elif isinstance(name, TypeName):
             return name.parts
         else:

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -111,9 +111,8 @@ class TypeName(
 
     def __new__(cls, *parts):
         return cls._from_parts_no_check(
-            sum(
-                map(cls.to_variableNames, parts),
-                (),
+            cls.__checked_parts(
+                parts
             )
         )
 
@@ -158,6 +157,30 @@ class TypeName(
             return parent
         else:
             return self
+
+    @staticmethod
+    def __checked_parts(
+        objs: typing.Iterable,
+    ) -> typing.Iterator[str]:
+
+        def not_checked_parts(
+        ) -> typing.Iterator[str]:
+            for obj in objs:
+                if isinstance(obj, TypeName):
+                    yield from obj.parts
+                elif isinstance(obj, VariableName):
+                    yield str(obj)
+                else:
+                    yield from split_type_specifier(str(obj))
+
+        for i, part in enumerate(
+            not_checked_parts()
+        ):
+            if part == "." and not i == 0:
+                raise ValueError(
+                    f"parts[{i}] is invalid, got {part!r}"
+                )
+            yield part
 
     @staticmethod
     def to_variableNames(

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -92,9 +92,7 @@ class VariableName(
                 f"Invalid modelica identifier, got {obj_str!r}"
             )
 
-        self = object.__new__(cls)
-        self.__str = obj_str
-        return self
+        return cls._from_str_no_check(obj_str)
 
     @classmethod
     def _from_str_no_check(

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -44,6 +44,15 @@ def split_type_specifier(
         raise ValueError(f"Invalid type_specifier, got {type_specifier!r}")
 
 
+def _VariableName_from_valid_identifier_no_check(
+    cls: typing.Type["VariableName"],
+    identifier: str,
+):
+    variableName = object.__new__(VariableName)
+    variableName._VariableName__str = identifier
+    return variableName
+
+
 class VariableName(
 ):
     __slots__ = "__str"

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -120,8 +120,8 @@ class TypeName(
     @property
     def parts(
         self,
-    ) -> typing.Tuple[VariableName, ...]:
-        return self.__parts
+    ) -> typing.Tuple[str, ...]:
+        return tuple(map(str, self.__parts))
 
     @property
     def last_identifier(

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -94,7 +94,6 @@ class VariableName(
     __to_omc_literal__ = __str__
 
 
-@functools.total_ordering
 class TypeName(
 ):
     __slots__ = (
@@ -179,9 +178,6 @@ class TypeName(
 
     def __eq__(self, other):
         return self.parts == type(self)(other).parts
-
-    def __lt__(self, other):
-        return self.parts < type(self)(other).parts
 
     def __repr__(
         self,

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -117,6 +117,15 @@ class TypeName(
         )
         return self
 
+    @classmethod
+    def _from_parts_no_check(
+        cls,
+        parts: typing.Iterable[str]
+    ) -> "TypeName":
+        self = super().__new__(cls)
+        self.__parts = parts
+        return self
+
     @property
     def parts(
         self,

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -59,7 +59,7 @@ class TypeSpecifierSplitVisitor(
     ) -> typing.Tuple[str, ...]:
         name = children.name[0]
         if node[0].value == ".":
-            return ("", *name)
+            return (".", *name)
         else:
             return name
 

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -145,14 +145,10 @@ class TypeName(
     def parents(
         self,
     ) -> typing.Iterator["TypeName"]:
-        parts = self.parts
-        if parts[0]:
-            begin = 0
-        else:
-            begin = 1
-        end = len(parts)
-        for end_of_slice in reversed(range(begin, end)):
-            yield type(self)(*parts[:end_of_slice])
+        for end in reversed(range(1, len(self.parts))):
+            yield type(self)._from_parts_no_check(
+                self.parts[:end]
+            )
 
     @property
     def parent(

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -30,35 +30,6 @@ def valid_identifier(
         return False
 
 
-class TypeSpecifierSplitVisitor(
-    arpeggio.PTNodeVisitor,
-):
-    def visit_IDENT(
-        self,
-        node,
-        children,
-    ) -> str:
-        return node.value
-
-    def visit_name(
-        self,
-        node,
-        children
-    ) -> typing.Tuple[str, ...]:
-        return tuple(children.IDENT)
-
-    def visit_type_specifier(
-        self,
-        node,
-        children,
-    ) -> typing.Tuple[str, ...]:
-        name = children.name[0]
-        if node[0].value == ".":
-            return (".", *name)
-        else:
-            return name
-
-
 def split_type_specifier(
     type_specifier: str
 ) -> typing.Tuple[str, ...]:
@@ -67,7 +38,7 @@ def split_type_specifier(
             parser.type_specifier_parser.parse(
                 type_specifier,
             ),
-            TypeSpecifierSplitVisitor()
+            visitor.TypeSpecifierSplitVisitor()
         )
     except arpeggio.NoMatch:
         raise ValueError(f"Invalid type_specifier, got {type_specifier!r}")
@@ -228,4 +199,5 @@ class TypeName(
 from omc4py.session import (  # noqa: E402
     parser,
     string,
+    visitor,
 )

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -1,0 +1,223 @@
+
+__all__ = (
+    "Boolean",
+    "Integer",
+    "Real",
+    "String",
+    "TypeName",
+    "VariableName",
+)
+
+import arpeggio  # type: ignore
+import functools
+import numpy
+import typing
+
+from omc4py.session import (
+    parser,
+    string,
+)
+
+
+Real = numpy.double
+Integer = numpy.intc
+Boolean = numpy.bool
+String = numpy.str
+
+
+def valid_identifier(
+    ident: str
+) -> bool:
+    try:
+        parser.IDENT_parser.parse(ident)
+        return True
+    except arpeggio.NoMatch:
+        return False
+
+
+class TypeSpecifierSplitVisitor(
+    arpeggio.PTNodeVisitor,
+):
+    def visit_IDENT(
+        self,
+        node,
+        children,
+    ) -> str:
+        return node.value
+
+    def visit_name(
+        self,
+        node,
+        children
+    ) -> typing.Tuple[str, ...]:
+        return tuple(children.IDENT)
+
+    def visit_type_specifier(
+        self,
+        node,
+        children,
+    ) -> typing.Tuple[str, ...]:
+        name = children.name[0]
+        if node[0].value == ".":
+            return ("", *name)
+        else:
+            return name
+
+
+def split_type_specifier(
+    type_specifier: str
+) -> typing.Tuple[str, ...]:
+    try:
+        return arpeggio.visit_parse_tree(
+            parser.type_specifier_parser.parse(
+                type_specifier,
+            ),
+            TypeSpecifierSplitVisitor()
+        )
+    except arpeggio.NoMatch:
+        raise ValueError(f"Invalid type_specifier, got {type_specifier!r}")
+
+
+class VariableName(
+):
+    __slots__ = "__str"
+
+    __str: str
+
+    def __new__(
+        cls,
+        obj,
+    ):
+        if isinstance(obj, VariableName):
+            return obj
+
+        obj_str = str(obj)
+        if not valid_identifier(obj_str):
+            raise ValueError(
+                f"Invalid modelica identifier, got {obj_str!r}"
+            )
+
+        self = object.__new__(cls)
+        self.__str = obj_str
+        return self
+
+    def __eq__(
+        self, other,
+    ):
+        if not isinstance(other, VariableName):
+            return False
+        else:
+            return str(self) == str(other)
+
+    def __hash__(
+        self,
+    ):
+        return hash(str(self))
+
+    def __str__(
+        self,
+    ) -> str:
+        return self.__str
+
+    def __repr__(
+        self,
+    ) -> str:
+        return f"{type(self).__name__}({str(self)!r})"
+
+    __to_omc_literal__ = __str__
+
+
+@functools.total_ordering
+class TypeName(
+):
+    __slots__ = (
+        "__parts",
+    )
+
+    __parts: typing.Tuple[VariableName, ...]
+
+    @property
+    def parts(
+        self,
+    ) -> typing.Tuple[VariableName, ...]:
+        return self.__parts
+
+    @property
+    def last_identifier(
+        self,
+    ) -> VariableName:
+        return VariableName(self.parts[-1])
+
+    @property
+    def parents(
+        self,
+    ) -> typing.Iterator["TypeName"]:
+        parts = self.parts
+        if parts[0]:
+            begin = 0
+        else:
+            begin = 1
+        end = len(parts)
+        for end_of_slice in reversed(range(begin, end)):
+            yield type(self)(*parts[:end_of_slice])
+
+    @property
+    def parent(
+        self,
+    ) -> "TypeName":
+        for parent in self.parents:
+            return parent
+        else:
+            return self
+
+    @staticmethod
+    def to_variableNames(
+        name: typing.Union[str, VariableName, "TypeName"]
+    ) -> typing.Tuple[VariableName, ...]:
+        if isinstance(name, str):
+            return tuple(
+                map(VariableName, split_type_specifier(name))
+            )
+        elif isinstance(name, VariableName):
+            return name,
+        elif isinstance(name, TypeName):
+            return name.parts
+        else:
+            raise TypeError()
+
+    def __new__(cls, *parts):
+        self = object.__new__(cls)
+        self.__parts = sum(
+            map(cls.to_variableNames, parts),
+            (),
+        )
+        return self
+
+    def __hash__(self):
+        return hash(self.parts)
+
+    def __eq__(self, other):
+        return self.parts == type(self)(other).parts
+
+    def __lt__(self, other):
+        return self.parts < type(self)(other).parts
+
+    def __repr__(
+        self,
+    ) -> str:
+        return f"{type(self).__name__}({str(self)!r})"
+
+    def __str__(
+        self,
+    ) -> str:
+        return ".".join(
+            map(string.to_omc_literal, self.parts)
+        )
+
+    __to_omc_literal__ = __str__
+
+    def __truediv__(
+        self,
+        other: typing.Union[str, VariableName, "TypeName"]
+    ):
+        return type(self)(self, other)

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -10,7 +10,7 @@ __all__ = (
 
 import arpeggio  # type: ignore
 import functools
-import numpy
+import numpy  # type: ignore
 import typing
 
 from omc4py.session import (

--- a/omc4py/primitive_types.py
+++ b/omc4py/primitive_types.py
@@ -200,7 +200,7 @@ class TypeName(
         self,
     ) -> str:
         if self.is_absolute:
-            return "." + ".".join(self.parts[1:])
+            return self.parts[0] + ".".join(self.parts[1:])
         else:
             return ".".join(self.parts)
 

--- a/omc4py/session/bootstrap/__init__.py
+++ b/omc4py/session/bootstrap/__init__.py
@@ -358,7 +358,7 @@ def generate_omc_interface_xml(
             else:
                 raise ValueError(f"Can't resolve {className} from {self.name}")
 
-            assert(self.name.parts[-1] == variableName)
+            assert(self.name.last_identifier == variableName)
             self.element.attrib["ref"] = str(candidate)
             return True
 

--- a/omc4py/session/bootstrap/profile/base.py
+++ b/omc4py/session/bootstrap/profile/base.py
@@ -177,4 +177,3 @@ class AbstractFunctionProfile(
         self,
     ) -> code.CodeBlock:
         raise NotImplementedError()
-

--- a/omc4py/session/string.py
+++ b/omc4py/session/string.py
@@ -7,7 +7,7 @@ __all__ = (
 
 
 from modelica_language.util import replace_all
-import numpy
+import numpy  # type: ignore
 import typing
 
 

--- a/omc4py/session/types.py
+++ b/omc4py/session/types.py
@@ -4,224 +4,24 @@ __all__ = (
     "Integer",
     "Real",
     "String",
-    "VariableName",
     "TypeName",
+    "VariableName",
 )
 
-
-import arpeggio  # type: ignore
-import functools
-import numpy
 import typing
 
 from . import (
-    parser,
     string,
 )
 
-
-Real = numpy.double
-Integer = numpy.intc
-Boolean = numpy.bool
-String = numpy.str
-
-
-def valid_identifier(
-    ident: str
-) -> bool:
-    try:
-        parser.IDENT_parser.parse(ident)
-        return True
-    except arpeggio.NoMatch:
-        return False
-
-
-class TypeSpecifierSplitVisitor(
-    arpeggio.PTNodeVisitor,
-):
-    def visit_IDENT(
-        self,
-        node,
-        children,
-    ) -> str:
-        return node.value
-
-    def visit_name(
-        self,
-        node,
-        children
-    ) -> typing.Tuple[str, ...]:
-        return tuple(children.IDENT)
-
-    def visit_type_specifier(
-        self,
-        node,
-        children,
-    ) -> typing.Tuple[str, ...]:
-        name = children.name[0]
-        if node[0].value == ".":
-            return ("", *name)
-        else:
-            return name
-
-
-def split_type_specifier(
-    type_specifier: str
-) -> typing.Tuple[str, ...]:
-    try:
-        return arpeggio.visit_parse_tree(
-            parser.type_specifier_parser.parse(
-                type_specifier,
-            ),
-            TypeSpecifierSplitVisitor()
-        )
-    except arpeggio.NoMatch:
-        raise ValueError(f"Invalid type_specifier, got {type_specifier!r}")
-
-
-class VariableName(
-):
-    __slots__ = "__str"
-
-    __str: str
-
-    def __new__(
-        cls,
-        obj,
-    ):
-        if isinstance(obj, VariableName):
-            return obj
-
-        obj_str = str(obj)
-        if not valid_identifier(obj_str):
-            raise ValueError(
-                f"Invalid modelica identifier, got {obj_str!r}"
-            )
-
-        self = object.__new__(cls)
-        self.__str = obj_str
-        return self
-
-    def __eq__(
-        self, other,
-    ):
-        if not isinstance(other, VariableName):
-            return False
-        else:
-            return str(self) == str(other)
-
-    def __hash__(
-        self,
-    ):
-        return hash(str(self))
-
-    def __str__(
-        self,
-    ) -> str:
-        return self.__str
-
-    def __repr__(
-        self,
-    ) -> str:
-        return f"{type(self).__name__}({str(self)!r})"
-
-    __to_omc_literal__ = __str__
-
-
-@functools.total_ordering
-class TypeName(
-):
-    __slots__ = (
-        "__parts",
-    )
-
-    __parts: typing.Tuple[VariableName, ...]
-
-    @property
-    def parts(
-        self,
-    ) -> typing.Tuple[VariableName, ...]:
-        return self.__parts
-
-    @property
-    def last_identifier(
-        self,
-    ) -> VariableName:
-        return VariableName(self.parts[-1])
-
-    @property
-    def parents(
-        self,
-    ) -> typing.Iterator["TypeName"]:
-        parts = self.parts
-        if parts[0]:
-            begin = 0
-        else:
-            begin = 1
-        end = len(parts)
-        for end_of_slice in reversed(range(begin, end)):
-            yield type(self)(*parts[:end_of_slice])
-
-    @property
-    def parent(
-        self,
-    ) -> "TypeName":
-        for parent in self.parents:
-            return parent
-        else:
-            return self
-
-    @staticmethod
-    def to_variableNames(
-        name: typing.Union[str, VariableName, "TypeName"]
-    ) -> typing.Tuple[VariableName, ...]:
-        if isinstance(name, str):
-            return tuple(
-                map(VariableName, split_type_specifier(name))
-            )
-        elif isinstance(name, VariableName):
-            return name,
-        elif isinstance(name, TypeName):
-            return name.parts
-        else:
-            raise TypeError()
-
-    def __new__(cls, *parts):
-        self = object.__new__(cls)
-        self.__parts = sum(
-            map(cls.to_variableNames, parts),
-            (),
-        )
-        return self
-
-    def __hash__(self):
-        return hash(self.parts)
-
-    def __eq__(self, other):
-        return self.parts == type(self)(other).parts
-
-    def __lt__(self, other):
-        return self.parts < type(self)(other).parts
-
-    def __repr__(
-        self,
-    ) -> str:
-        return f"{type(self).__name__}({str(self)!r})"
-
-    def __str__(
-        self,
-    ) -> str:
-        return ".".join(
-            map(string.to_omc_literal, self.parts)
-        )
-
-    __to_omc_literal__ = __str__
-
-    def __truediv__(
-        self,
-        other: typing.Union[str, VariableName, "TypeName"]
-    ):
-        return type(self)(self, other)
+from ..primitive_types import (
+    Real,
+    Integer,
+    Boolean,
+    String,
+    VariableName,
+    TypeName,
+)
 
 
 RecordFields = typing.Dict[

--- a/omc4py/session/types.py
+++ b/omc4py/session/types.py
@@ -6,7 +6,6 @@ __all__ = (
 
 
 import arpeggio  # type: ignore
-import collections
 import functools
 import typing
 

--- a/omc4py/session/types.py
+++ b/omc4py/session/types.py
@@ -1,5 +1,9 @@
 
 __all__ = (
+    "Boolean",
+    "Integer",
+    "Real",
+    "String",
     "VariableName",
     "TypeName",
 )
@@ -7,12 +11,19 @@ __all__ = (
 
 import arpeggio  # type: ignore
 import functools
+import numpy
 import typing
 
 from . import (
     parser,
     string,
 )
+
+
+Real = numpy.double
+Integer = numpy.intc
+Boolean = numpy.bool
+String = numpy.str
 
 
 def valid_identifier(

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -41,6 +41,35 @@ def getitem_with_default(
             raise
 
 
+class TypeSpecifierSplitVisitor(
+    arpeggio.PTNodeVisitor,
+):
+    def visit_IDENT(
+        self,
+        node,
+        children,
+    ) -> str:
+        return node.value
+
+    def visit_name(
+        self,
+        node,
+        children
+    ) -> typing.Tuple[str, ...]:
+        return tuple(children.IDENT)
+
+    def visit_type_specifier(
+        self,
+        node,
+        children,
+    ) -> typing.Tuple[str, ...]:
+        name = children.name[0]
+        if node[0].value == ".":
+            return (".", *name)
+        else:
+            return name
+
+
 class TypeSpecifierVisitor(
     arpeggio.PTNodeVisitor,
 ):

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -77,14 +77,14 @@ class TypeSpecifierVisitor(
         self,
         node,
         children
-    ) -> VariableName:
-        return VariableName(node.value)
+    ) -> str:
+        return node.value
 
     def visit_name(
         self,
         node,
         children,
-    ) -> typing.Tuple[VariableName, ...]:
+    ) -> typing.Tuple[str, ...]:
         return tuple(children.IDENT)
 
     def visit_type_specifier(
@@ -94,9 +94,9 @@ class TypeSpecifierVisitor(
     ) -> TypeName:
         name = children.name[0]
         if node[0].value == ".":
-            return TypeName(VariableName(), *name)
+            return TypeName._from_parts_no_check((".", *name))
         else:
-            return TypeName(*name)
+            return TypeName._from_parts_no_check(name)
 
 
 class NumberVisitor(
@@ -307,7 +307,7 @@ class AliasVisitor(
         node,
         children
     ) -> typing.Optional[typing.Tuple[VariableName, TypeName]]:
-        variableName, = children.IDENT
+        variableName = VariableName(children.IDENT[0])
         type_specifier = getitem_with_default(
             children.type_specifier, 0,
             default=None

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -1,7 +1,7 @@
 
 import arpeggio  # type: ignore
 import enum
-import numpy
+import numpy  # type: ignore
 import operator
 import typing
 

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -6,9 +6,10 @@ import operator
 import typing
 
 from . import string
-from .types import (
+from omc4py.primitive_types import (
     VariableName,
     TypeName,
+    _TypeName_from_valid_parts_no_check,
 )
 
 
@@ -94,9 +95,15 @@ class TypeSpecifierVisitor(
     ) -> TypeName:
         name = children.name[0]
         if node[0].value == ".":
-            return TypeName._from_parts_no_check((".", *name))
+            return _TypeName_from_valid_parts_no_check(
+                TypeName,
+                (".", *name),
+            )
         else:
-            return TypeName._from_parts_no_check(name)
+            return _TypeName_from_valid_parts_no_check(
+                TypeName,
+                name,
+            )
 
 
 class NumberVisitor(

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -175,7 +175,7 @@ class OMCRecordVisitor(
         self,
         node,
         children,
-    ) -> typing.Tuple[VariableName, typing.Any]:
+    ) -> typing.Tuple[str, typing.Any]:
         IDENT = children.IDENT[0]
         value = children.omc_value[0]
         return str(IDENT), value

--- a/omc4py/session/visitor.py
+++ b/omc4py/session/visitor.py
@@ -8,7 +8,6 @@ import typing
 from . import string
 from .types import (
     VariableName,
-    OMCRecord,
     TypeName,
 )
 


### PR DESCRIPTION
Improve `omc4py.session.types.(TypeName, VariableName)` -> `omc4py.primitive_types.(TypeName, VariableName)`

## `omc4py.primitive_types.VariableName`

- Add hidden factory function for internal non-overhead instantiation

## `omc4py.primitive_types.TypeName`

- Add hidden factory function for internal non-overhead instantiation
- Update to support absolute reference s.t. `.OpenModelica` (start with __.__ )
- Fix signature for `TypeName.parts` from VariableName tuple to str tuple (parts may contain "." but it is not VariableName)