### PR TITLE
Refactor/variablename in visitor

### DIFF
--- a/bootstrap/__init__.py
+++ b/bootstrap/__init__.py
@@ -402,7 +402,7 @@ def generate_omc_interface_xml(
                 if component.protected == "protected":
                     continue
                 hasDefault = variableHasDefault[
-                    types.VariableName(component.name)
+                    component.name
                 ]
                 argument_element = xml.SubElement(
                     arguments_element,

--- a/bootstrap/parser/visitor.py
+++ b/bootstrap/parser/visitor.py
@@ -49,7 +49,7 @@ class AliasVisitor(
         node,
         children
     ) -> typing.Optional[typing.Tuple[VariableName, TypeName]]:
-        variableName = VariableName(children.IDENT[0])
+        variableName, = children.IDENT
         type_specifier = getitem_with_default(
             children.type_specifier, 0,
             default=None
@@ -75,7 +75,7 @@ class EnumeratorsVisitor(
     TypeSpecifierVisitor,
     StringVisitor,
 ):
-    def visit_stored_definition(
+    def visit__default__(
         self,
         node,
         children,
@@ -86,19 +86,12 @@ class EnumeratorsVisitor(
             if isinstance(child, Enumerator)
         ]
 
-    def visit_enum_list(
-        self,
-        node,
-        children,
-    ) -> typing.List[Enumerator]:
-        return children.enumeration_literal
-
     def visit_enumeration_literal(
         self,
         node,
         children,
     ) -> Enumerator:
-        name = children.IDENT[0]
+        name, = children.IDENT
         comment = getitem_with_default(
             children.comment, 0,
             default=""
@@ -149,7 +142,7 @@ class VariableHasDefaultVisitor(
         node,
         children
     ) -> VariableHasDefault:
-        name = VariableName(children.IDENT[0])
+        name, = children.IDENT
         hasDefault = bool(children.modification)
         return VariableHasDefault(
             name=name,

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -1,7 +1,9 @@
 
 __all__ = (
-    "_TypeName_from_str",
-    "valid_identifier",
+    "is_valid_identifier",
+    "parse_OMCValue",
+    "parse_typeName",
+    "parse_components",
 )
 
 import arpeggio  # type: ignore
@@ -37,7 +39,7 @@ with syntax.omc_dialect_context:
     )
 
 
-def valid_identifier(
+def is_valid_identifier(
     ident: str
 ) -> bool:
     try:
@@ -47,7 +49,7 @@ def valid_identifier(
         return False
 
 
-def _TypeName_from_str(
+def parse_typeName(
     type_specifier: str
 ) -> TypeName:
     try:

--- a/omc4py/parser/visitor.py
+++ b/omc4py/parser/visitor.py
@@ -11,7 +11,6 @@ from omc4py.types import (
     Real,
     TypeName,
     VariableName,
-    _TypeName_from_valid_parts_no_check,
 )
 
 from omc4py import string

--- a/omc4py/parser/visitor.py
+++ b/omc4py/parser/visitor.py
@@ -53,15 +53,17 @@ class TypeSpecifierVisitor(
         self,
         node,
         children,
-    ) -> str:
-        return node.value
+    ) -> VariableName:
+        return VariableName.__from_valid_identifier_no_check__(
+            node.value
+        )
 
     def visit_name(
         self,
         node,
         children,
-    ) -> typing.Tuple[str, ...]:
-        return tuple(children.IDENT)
+    ) -> typing.List[VariableName]:
+        return children.IDENT
 
     def visit_type_specifier(
         self,
@@ -70,15 +72,9 @@ class TypeSpecifierVisitor(
     ) -> TypeName:
         name = children.name[0]
         if node[0].value == ".":
-            return _TypeName_from_valid_parts_no_check(
-                TypeName,
-                (".", *name),
-            )
+            return TypeName(".", *name)
         else:
-            return _TypeName_from_valid_parts_no_check(
-                TypeName,
-                name,
-            )
+            return TypeName(*name)
 
 
 class NumberVisitor(

--- a/omc4py/types.py
+++ b/omc4py/types.py
@@ -41,10 +41,18 @@ class VariableName(
                 f"Invalid modelica identifier, got {obj_str!r}"
             )
 
-        return _VariableName_from_valid_identifier_no_check(
-            cls,
+        return cls.__from_valid_identifier_no_check__(
             obj_str
         )
+
+    @classmethod
+    def __from_valid_identifier_no_check__(
+        cls,
+        identifier: str
+    ) -> "VariableName":
+        variableName = object.__new__(cls)
+        variableName.__str = identifier
+        return variableName
 
     def __eq__(
         self, other,
@@ -185,15 +193,6 @@ class TypeName(
         other: typing.Union[str, VariableName, "TypeName"]
     ):
         return type(self)(self, other)
-
-
-def _VariableName_from_valid_identifier_no_check(
-    cls: typing.Type["VariableName"],
-    identifier: str,
-):
-    variableName = object.__new__(VariableName)
-    variableName._VariableName__str = identifier
-    return variableName
 
 
 def _TypeName_from_valid_parts_no_check(

--- a/omc4py/types.py
+++ b/omc4py/types.py
@@ -36,7 +36,7 @@ class VariableName(
             return obj
 
         obj_str = str(obj)
-        if not parser.valid_identifier(obj_str):
+        if not parser.is_valid_identifier(obj_str):
             raise ValueError(
                 f"Invalid modelica identifier, got {obj_str!r}"
             )
@@ -105,7 +105,7 @@ class TypeName(
         cls,
         s: str
     ) -> "TypeName":
-        return parser._TypeName_from_str(s)
+        return parser.parse_typeName(s)
 
     @classmethod
     def __from_valid_parts_no_check__(

--- a/omc4py/types.py
+++ b/omc4py/types.py
@@ -94,8 +94,7 @@ class TypeName(
             if isinstance(part, TypeName):
                 return part
 
-        return _TypeName_from_valid_parts_no_check(
-            cls,
+        return cls.__from_valid_parts_no_check__(
             cls.__checked_parts(
                 parts
             )
@@ -107,6 +106,15 @@ class TypeName(
         s: str
     ) -> "TypeName":
         return parser._TypeName_from_str(s)
+
+    @classmethod
+    def __from_valid_parts_no_check__(
+        cls,
+        parts: typing.Iterable[typing.Union[str, VariableName]],
+    ):
+        typeName = object.__new__(TypeName)
+        typeName._TypeName__parts = tuple(map(str, parts))
+        return typeName
 
     @property
     def parts(
@@ -128,8 +136,7 @@ class TypeName(
         self,
     ) -> typing.Iterator["TypeName"]:
         for end in reversed(range(1, len(self.parts))):
-            yield _TypeName_from_valid_parts_no_check(
-                type(self),
+            yield self.__from_valid_parts_no_check__(
                 self.parts[:end],
             )
 
@@ -146,15 +153,15 @@ class TypeName(
     def __checked_parts(
         cls,
         objs: typing.Iterable,
-    ) -> typing.Iterator[str]:
+    ) -> typing.Iterator[typing.Union[str, VariableName]]:
 
         def not_checked_parts(
-        ) -> typing.Iterator[str]:
+        ) -> typing.Iterator[typing.Union[str, VariableName]]:
             for obj in objs:
                 if isinstance(obj, TypeName):
                     yield from obj.parts
                 elif isinstance(obj, VariableName):
-                    yield str(obj)
+                    yield obj
                 else:
                     yield from cls.from_str(str(obj)).parts
 
@@ -193,15 +200,6 @@ class TypeName(
         other: typing.Union[str, VariableName, "TypeName"]
     ):
         return type(self)(self, other)
-
-
-def _TypeName_from_valid_parts_no_check(
-    cls: typing.Type["TypeName"],
-    parts: typing.Iterable[str],
-):
-    typeName = object.__new__(TypeName)
-    typeName._TypeName__parts = tuple(parts)
-    return typeName
 
 
 class OMCEnumerationMeta(


### PR DESCRIPTION
Refactor `omc4py.parser.visitor.TypeSpecifierVisior` returns VariableName for IDENT rule.