### PR TITLE
Refactor/parser

### DIFF
--- a/bootstrap/parser/__init__.py
+++ b/bootstrap/parser/__init__.py
@@ -1,7 +1,6 @@
 
 __all__ = (
     "parse_alias",
-    "parse_components",
     "parse_enumerators",
     "parse_variableHasDefault",
 )
@@ -9,10 +8,8 @@ __all__ = (
 import arpeggio  # type: ignore
 import typing
 
-from omc4py.parser import (
-    parse_components,
-    stored_definition_parser,
-)
+import omc4py.parser.syntax
+
 from omc4py.classes import (
     TypeName,
     VariableName,
@@ -21,11 +18,19 @@ from omc4py.classes import (
 from . import visitor
 
 
+@omc4py.parser.omc_parser_getter
+def get_stored_definition_parser() -> arpeggio.Parser:
+    return arpeggio.ParserPython(
+        omc4py.parser.syntax.stored_definition_withEOF,
+        omc4py.parser.syntax.std.CPP_STYLE_COMMENT,
+    )
+
+
 def parse_alias(
     code: str
 ) -> typing.Optional[typing.Tuple[VariableName, TypeName]]:
     return arpeggio.visit_parse_tree(
-        stored_definition_parser.parse(code),
+        get_stored_definition_parser().parse(code),
         visitor.AliasVisitor(),
     )
 
@@ -34,7 +39,7 @@ def parse_enumerators(
     code: str
 ) -> typing.List[typing.Tuple[VariableName, str]]:
     return arpeggio.visit_parse_tree(
-        stored_definition_parser.parse(code),
+        get_stored_definition_parser().parse(code),
         visitor.EnumeratorsVisitor(),
     )
 
@@ -44,7 +49,7 @@ def parse_variableHasDefault(
 ) -> typing.Dict[VariableName, bool]:
     return dict(
         arpeggio.visit_parse_tree(
-            stored_definition_parser.parse(code),
+            get_stored_definition_parser().parse(code),
             visitor.VariableHasDefaultVisitor(),
         )
     )

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -39,22 +39,31 @@ def get_IDENT_parser() -> arpeggio.Parser:
     )
 
 
-with syntax.omc_dialect_context:
-    type_specifier_parser = arpeggio.ParserPython(
+@omc_parser_getter
+def get_type_specifier_parser() -> arpeggio.Parser:
+    return arpeggio.ParserPython(
         syntax.type_specifier_withEOF,
     )
 
-    stored_definition_parser = arpeggio.ParserPython(
-        syntax.stored_definition_withEOF,
-        syntax.std.CPP_STYLE_COMMENT,
-    )
 
-    omc_record_array_parser = arpeggio.ParserPython(
+@omc_parser_getter
+def get_omc_record_array_parser() -> arpeggio.Parser:
+    return arpeggio.ParserPython(
         syntax.omc_component_array_withEOF,
     )
 
-    omc_value_parser = arpeggio.ParserPython(
+
+@omc_parser_getter
+def get_omc_value_parser() -> arpeggio.Parser:
+    return arpeggio.ParserPython(
         syntax.omc_value_withEOF,
+    )
+
+
+with syntax.omc_dialect_context:
+    stored_definition_parser = arpeggio.ParserPython(
+        syntax.stored_definition_withEOF,
+        syntax.std.CPP_STYLE_COMMENT,
     )
 
 
@@ -73,7 +82,7 @@ def parse_typeName(
 ) -> TypeName:
     try:
         return arpeggio.visit_parse_tree(
-            type_specifier_parser.parse(
+            get_type_specifier_parser().parse(
                 type_specifier,
             ),
             visitor.TypeSpecifierVisitor()
@@ -86,7 +95,7 @@ def parse_components(
     literal: str
 ) -> typing.List[ComponentTuple]:
     return arpeggio.visit_parse_tree(
-        omc_record_array_parser.parse(literal),
+        get_omc_record_array_parser().parse(literal),
         visitor.ComponentArrayVisitor(source=literal),
     )
 
@@ -95,6 +104,6 @@ def parse_OMCValue(
     literal: str
 ):
     return arpeggio.visit_parse_tree(
-        omc_value_parser.parse(literal),
+        get_omc_value_parser().parse(literal),
         visitor.OMCValueVisitor()
     )

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -60,13 +60,6 @@ def get_omc_value_parser() -> arpeggio.Parser:
     )
 
 
-with syntax.omc_dialect_context:
-    stored_definition_parser = arpeggio.ParserPython(
-        syntax.stored_definition_withEOF,
-        syntax.std.CPP_STYLE_COMMENT,
-    )
-
-
 def is_valid_identifier(
     ident: str
 ) -> bool:


### PR DESCRIPTION
Stop to generate parser when imported. Define cached getter function when import.

It speed-up import

```bash
# before
$ python3 -m timeit -n 100 "import sys;import omc4py;[sys.modules.pop(key) for key in list(sys.modules) if 'omc4py' in key]"
100 loops, best of 5: 9.82 msec per loop
# after
$ python3 -m timeit -n 100 "import sys;import omc4py;[sys.modules.pop(key) for key in list(sys.modules) if 'omc4py' in key]"
100 loops, best of 5: 5.22 msec per loop
```