### PR TITLE
Refactor/enumeration constructor

### DIFF
--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -383,7 +383,9 @@ class ModelicaEnumerationMeta(
         value,
     ):
         if isinstance(value, TypeName):
-            if not value.parent == cls.__modelica_name__:
+            valueClassName = value.parent
+            expectedClassName = cls.__modelica_name__
+            if valueClassName.as_absolute() != expectedClassName.as_absolute():
                 raise KeyError(
                     f"value: TypeName must be {cls.__modelica_name__}.* "
                     f"got {value!s}"

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -156,6 +156,12 @@ class TypeName(
     @property
     def is_absolute(self) -> bool: return str(self.parts[0]) == "."
 
+    def as_absolute(self):
+        if self.is_absolute:
+            return self
+        else:
+            return TypeName(".", self)
+
     @property
     def last_identifier(
         self,


### PR DESCRIPTION
Fix bug shown below

```python3
from omc4py.classes import (
    ModelicaEnumeration,
    TypeName,
    enum,
    modelica_name,
)


@modelica_name("SomeEnum")
class SomeEnum(
    ModelicaEnumeration,
):
    a = enum.auto()
    b = enum.auto()
    c = enum.auto()


SomeEnum(TypeName(".SomeEnum.a"))  # raise error
SomeEnum(TypeName("SomeEnum.a"))  # OK
```