### PR TITLE
Refactor/open session

### DIFF
--- a/omc4py/__init__.py
+++ b/omc4py/__init__.py
@@ -63,20 +63,41 @@ def open_session(
             yield v_1_16.OMCSession(omc)
 
 
-def open_session2(
-    omc_command: typing.Optional[compiler.StrOrPathLike] = None,
-) -> classes.AbstractOMCSession:
-    omc = compiler.OMCInteractive.open(omc_command)
+def __select_session_type(
+    omc: classes.AbstractOMCInteractive,
+) -> typing.Type[classes.AbstractOMCSession]:
     version = session.OMCSessionMinimal(omc).getVersionTuple()
     if version[:2] <= (1, 13):
         from . import v_1_13
-        return v_1_13.OMCSession(omc)
+        return v_1_13.OMCSession
     elif version[:2] == (1, 14):
         from . import v_1_14
-        return v_1_14.OMCSession(omc)
+        return v_1_14.OMCSession
     elif version[:2] == (1, 15):
         from . import v_1_15
-        return v_1_15.OMCSession(omc)
+        return v_1_15.OMCSession
     else:  # version[:2] >= (1, 16):
         from . import v_1_16
-        return v_1_16.OMCSession(omc)
+        return v_1_16.OMCSession
+
+
+def open_session2(
+    omc_command: typing.Optional[compiler.StrOrPathLike] = None,
+    *,
+    session_type: typing.Optional[
+        typing.Type[classes.AbstractOMCSession]
+    ] = None,
+) -> classes.AbstractOMCSession:
+    omc = compiler.OMCInteractive.open(omc_command)
+
+    if session_type is None:
+        session_type = __select_session_type(omc)
+    else:
+        if not issubclass(session_type, classes.AbstractOMCSession):
+            raise TypeError(
+                "session_type must be "
+                f"subclass of {classes.AbstractOMCSession}, "
+                f"got {session_type}"
+            )
+
+    return session_type(omc)

--- a/omc4py/__init__.py
+++ b/omc4py/__init__.py
@@ -61,3 +61,22 @@ def open_session(
         elif version[:2] >= (1, 16):
             from . import v_1_16
             yield v_1_16.OMCSession(omc)
+
+
+def open_session2(
+    omc_command: typing.Optional[compiler.StrOrPathLike] = None,
+) -> classes.AbstractOMCSession:
+    omc = compiler.OMCInteractive.open(omc_command)
+    version = session.OMCSessionMinimal(omc).getVersionTuple()
+    if version[:2] <= (1, 13):
+        from . import v_1_13
+        return v_1_13.OMCSession(omc)
+    elif version[:2] == (1, 14):
+        from . import v_1_14
+        return v_1_14.OMCSession(omc)
+    elif version[:2] == (1, 15):
+        from . import v_1_15
+        return v_1_15.OMCSession(omc)
+    else:  # version[:2] >= (1, 16):
+        from . import v_1_16
+        return v_1_16.OMCSession(omc)

--- a/omc4py/__init__.py
+++ b/omc4py/__init__.py
@@ -32,7 +32,6 @@ __license__ = '''
  */
 '''
 
-from contextlib import contextmanager
 import typing
 
 from . import (
@@ -42,46 +41,7 @@ from . import (
 )
 
 
-@contextmanager
 def open_session(
-    omc_command: typing.Optional[compiler.StrOrPathLike] = None,
-) -> typing.Iterator[classes.AbstractOMCSession]:
-    with compiler.OMCInteractive.open(omc_command) as omc:
-        sessionMinimal = session.OMCSessionMinimal(omc)
-        version = sessionMinimal.getVersionTuple()
-        if version[:2] <= (1, 13):
-            from . import v_1_13
-            yield v_1_13.OMCSession(omc)
-        elif version[:2] == (1, 14):
-            from . import v_1_14
-            yield v_1_14.OMCSession(omc)
-        elif version[:2] == (1, 15):
-            from . import v_1_15
-            yield v_1_15.OMCSession(omc)
-        elif version[:2] >= (1, 16):
-            from . import v_1_16
-            yield v_1_16.OMCSession(omc)
-
-
-def __select_session_type(
-    omc: classes.AbstractOMCInteractive,
-) -> typing.Type[classes.AbstractOMCSession]:
-    version = session.OMCSessionMinimal(omc).getVersionTuple()
-    if version[:2] <= (1, 13):
-        from . import v_1_13
-        return v_1_13.OMCSession
-    elif version[:2] == (1, 14):
-        from . import v_1_14
-        return v_1_14.OMCSession
-    elif version[:2] == (1, 15):
-        from . import v_1_15
-        return v_1_15.OMCSession
-    else:  # version[:2] >= (1, 16):
-        from . import v_1_16
-        return v_1_16.OMCSession
-
-
-def open_session2(
     omc_command: typing.Optional[compiler.StrOrPathLike] = None,
     *,
     session_type: typing.Optional[
@@ -101,3 +61,21 @@ def open_session2(
             )
 
     return session_type(omc)
+
+
+def __select_session_type(
+    omc: classes.AbstractOMCInteractive,
+) -> typing.Type[classes.AbstractOMCSession]:
+    version = session.OMCSessionMinimal(omc).getVersionTuple()
+    if version[:2] <= (1, 13):
+        from . import v_1_13
+        return v_1_13.OMCSession
+    elif version[:2] == (1, 14):
+        from . import v_1_14
+        return v_1_14.OMCSession
+    elif version[:2] == (1, 15):
+        from . import v_1_15
+        return v_1_15.OMCSession
+    else:  # version[:2] >= (1, 16):
+        from . import v_1_16
+        return v_1_16.OMCSession

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -290,9 +290,7 @@ class AbstractOMCInteractive(
 
     def __exit__(
         self,
-        exc_type,
-        exc_value,
-        traceback,
+        exc_type, exc_value, traceback,
     ) -> typing_extensions.Literal[False]:
         self.close()
         return False
@@ -315,6 +313,18 @@ class AbstractOMCSession(
 
     @abc.abstractmethod
     def __omc_check__(self) -> None: ...
+
+    def __enter__(self) -> "AbstractOMCSession": return self
+
+    def __close__(self):
+        self.__omc__.close()
+
+    def __exit__(
+        self,
+        exc_type, exc_value, traceback,
+    ) -> typing_extensions.Literal[False]:
+        self.__close__()
+        return False
 
 
 # Meta classes for modelica-like class


### PR DESCRIPTION
Update `omc4py.classes.AbstractOMCSession` as contextmanager.
Thus, open_session is available not only with-statement.
When open_session is called not in with-statament, session.__close__ call will be needed.