### PR TITLE
Refactor/__omc_check__  

### DIFF
--- a/bootstrap/session.py
+++ b/bootstrap/session.py
@@ -46,7 +46,7 @@ class OMCSessionBootstrap(
             ],
             parser=parse_OMCValue,
         )
-        self.__omc_check__()
+        self.__check__()
         return str(__result)
 
     def getClassNames(
@@ -67,7 +67,7 @@ class OMCSessionBootstrap(
             ],
             parser=parse_OMCValue,
         )
-        self.__omc_check__()
+        self.__check__()
         return list(__result)
 
     def getClassRestriction(
@@ -84,7 +84,7 @@ class OMCSessionBootstrap(
             ],
             parser=parse_OMCValue,
         )
-        self.__omc_check__()
+        self.__check__()
         return str(__result)
 
     class RestrictionEnum(

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -312,7 +312,7 @@ class AbstractOMCSession(
         return self.__omc
 
     @abc.abstractmethod
-    def __omc_check__(self) -> None: ...
+    def __check__(self) -> None: ...
 
     def __enter__(self) -> "AbstractOMCSession": return self
 

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -715,13 +715,13 @@ class Component(
         if value is None:
             if required == "required":
                 raise ValueError(
-                    f"required value {name!r} is None"
+                    f"Required value {name!r} is None"
                 )
             if required == "optional":
                 return None
             else:
                 raise ValueError(
-                    f"required must be (required|optional) got {required!r}"
+                    f"'required' must be (required|optional) got {required!r}"
                 )
 
         value_array = numpy.array(value, dtype=object)
@@ -748,10 +748,16 @@ class Component(
                 value_array
             )
             if not numpy.all(isinstance_mask):
-                raise TypeError(
-                    f"{name!r} or all items of {name!r}"
-                    f"must be instances of {self.class_restrictions}"
-                )
+                if self.is_scalar:
+                    raise TypeError(
+                        f"{name!r} "
+                        f"must be instance of {self.class_restrictions}"
+                    )
+                else:
+                    raise TypeError(
+                        f"All items of {name!r} "
+                        f"must be instances of {self.class_restrictions}"
+                    )
 
         if self.is_scalar:
             return self.class_(value)

--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -1,7 +1,6 @@
 
 import atexit
 import logging
-import numpy  # type: ignore
 import os
 from pathlib import Path
 import shutil
@@ -14,7 +13,6 @@ import zmq  # type: ignore
 
 from . import (
     classes,
-    exception,
     string,
 )
 
@@ -242,9 +240,9 @@ class OMCInteractive(
             )
         )
 
-        if (not result_literal or result_literal.isspace():
+        if not result_literal or result_literal.isspace():
             if outputArguments:
-                raise exception.OMCRuntimeError(
+                raise ValueError(
                     f"Unexpected empty result, got {result_literal!r}"
                 )
             else:
@@ -253,12 +251,12 @@ class OMCInteractive(
         try:
             result_value = parser(result_literal)
         except Exception:
-            raise exception.OMCRuntimeError(
+            raise ValueError(
                 f"Failed to parse {result_literal!r}"
             ) from None
 
         if len(outputArguments) == 0:
-            raise exception.OMCRuntimeError(
+            raise ValueError(
                 "There is no output variable in the function, "
                 f"but omc returns {result_value!r}"
             )
@@ -267,9 +265,9 @@ class OMCInteractive(
             return component.cast(name, result_value)
         else:
             if len(result_value) != len(outputArguments):
-                raise exception.OMCRuntimeError(
+                raise ValueError(
                     f"Size of result must be [{len(outputArguments)}], "
-                    f"got {result_value!r} size=[{len(result_value)}]"
+                    f"got {result_value!r} size is [{len(result_value)}]"
                 )
             return tuple(
                 component.cast(name, value)

--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -14,6 +14,7 @@ import zmq  # type: ignore
 
 from . import (
     classes,
+    exception,
     string,
 )
 
@@ -248,7 +249,10 @@ class OMCInteractive(
                 )
             return
 
-        result_value = parser(result_literal)
+        try:
+            result_value = parser(result_literal)
+        except Exception:
+            raise exception.OMCError(result_literal)
 
         if len(outputArguments) == 1:
             (component, name,), = outputArguments

--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -242,22 +242,35 @@ class OMCInteractive(
             )
         )
 
-        if not outputArguments:
-            if result_literal and not result_literal.isspace():
-                raise ValueError(
-                    f"Unexpected result, got {result_literal!r}"
+        if (not result_literal or result_literal.isspace():
+            if outputArguments:
+                raise exception.OMCRuntimeError(
+                    f"Unexpected empty result, got {result_literal!r}"
                 )
-            return
+            else:
+                return None
 
         try:
             result_value = parser(result_literal)
         except Exception:
-            raise exception.OMCError(result_literal)
+            raise exception.OMCRuntimeError(
+                f"Failed to parse {result_literal!r}"
+            ) from None
 
+        if len(outputArguments) == 0:
+            raise exception.OMCRuntimeError(
+                "There is no output variable in the function, "
+                f"but omc returns {result_value!r}"
+            )
         if len(outputArguments) == 1:
             (component, name,), = outputArguments
             return component.cast(name, result_value)
         else:
+            if len(result_value) != len(outputArguments):
+                raise exception.OMCRuntimeError(
+                    f"Size of result must be [{len(outputArguments)}], "
+                    f"got {result_value!r} size=[{len(result_value)}]"
+                )
             return tuple(
                 component.cast(name, value)
                 for (component, name), value in zip(

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -31,14 +31,14 @@ class OMCSessionBase(
         __result = parse_components(
             self.__omc__.evaluate(f"getComponents({TypeName(name)})")
         )
-        self.__omc_check__()
+        self.__check__()
         return __result
 
 
 class OMCSessionBase__v_1_13(
     OMCSessionBase,
 ):
-    def __omc_check__(
+    def __check__(
         self,
     ):
         for messageString in self.getMessagesStringInternal(unique=True):
@@ -96,7 +96,7 @@ def parse_OMCError(
 class OMCSessionMinimal(
     OMCSessionBase,
 ):
-    def __omc_check__(
+    def __check__(
         self,
     ) -> None:
         for errorString in self.getErrorString().splitlines():
@@ -135,7 +135,7 @@ class OMCSessionMinimal(
             ],
             parser=parse_OMCValue,
         )
-        self.__omc_check__()
+        self.__check__()
         return str(__result)
 
     def getVersionTuple(

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -1,4 +1,5 @@
 
+import functools
 import re
 import typing
 import warnings
@@ -62,9 +63,11 @@ class OMCSessionBase__v_1_13(
                 )
 
 
-omc_error_pattern = re.compile(
-    r"(\[(?P<info>[^]]*)\]\s+)?(?P<kind>\w+):\s+(?P<message>.*)"
-)
+@functools.lru_cache(1)
+def get_omc_error_regex():
+    return re.compile(
+        r"(\[(?P<info>[^]]*)\]\s+)?(?P<kind>\w+):\s+(?P<message>.*)"
+    )
 
 
 def parse_OMCError(
@@ -73,7 +76,7 @@ def parse_OMCError(
     if not error_string or error_string.isspace():
         return None
 
-    matched = omc_error_pattern.match(
+    matched = get_omc_error_regex().match(
         error_string
     )
     if not matched:
@@ -84,7 +87,7 @@ def parse_OMCError(
     kind = matched.group("kind")
     # message = matched.group("message")
 
-    if kind == "Error":
+    if kind.lower() == "error":
         return exception.OMCError(error_string)
     else:
         return exception.OMCWarning(error_string)
@@ -96,19 +99,15 @@ class OMCSessionMinimal(
     def __omc_check__(
         self,
     ) -> None:
-        error_optional = parse_OMCError(self.getErrorString())
-        error: exception.OMCException
-        if error_optional is None:
-            return
-        else:
-            error = error_optional
+        for errorString in self.getErrorString().splitlines():
+            error = parse_OMCError(errorString)
+            if error is None:
+                return
 
-        if isinstance(error, Warning):
-            warnings.warn(error)
-        else:
-            raise error
-
-        self.__omc_check__()
+            if isinstance(error, Warning):
+                warnings.warn(error)
+            else:
+                raise error
 
     def getErrorString(
         self,


### PR DESCRIPTION
Refactor `omc4py.classes.AbstractOMCSession.__omc_check__` method

- Rename `__omc_check__` => `__check__`
- Refactor `__check__` of `omc4py.session.OMCSessionMinimal` (treat multi-line message)
- Update error check in `omc4py.compiler.OMCInteractive.call_function`
- Update error check in `omc4py.classes.Component.cast`
