### PR TITLE
Refactor/type name

### DIFF
--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -128,11 +128,10 @@ class TypeName(
             if isinstance(part, TypeName):
                 return part
 
-        return cls.__from_valid_parts_no_check__(
-            cls.__split_parts(
-                (part, *parts)
-            )
-        )
+        self = super().__new__(TypeName)
+        self.__parts = tuple(cls.__split_parts((part, *parts)))
+
+        return self
 
     @staticmethod
     def __split_parts(
@@ -164,15 +163,6 @@ class TypeName(
             raise TypeError(
                 f"Unexpected part, got {part}: {type(part)}"
             )
-
-    @classmethod
-    def __from_valid_parts_no_check__(
-        cls,
-        parts: typing.Iterable[str],
-    ):
-        typeName = object.__new__(TypeName)
-        typeName.__parts = tuple(parts)
-        return typeName
 
     @property
     def parts(

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -134,6 +134,37 @@ class TypeName(
             )
         )
 
+    @staticmethod
+    def __split_parts(
+        parts,
+    ) -> typing.Iterator[str]:
+        for i, part in enumerate(
+            itertools.chain(*map(TypeName.__split_part, parts))
+        ):
+            if part == "." and not i == 0:
+                raise ValueError(
+                    f"parts[{i}] is invalid, got {part!r}"
+                )
+            yield part
+
+    @staticmethod
+    def __split_part(
+        part,
+    ) -> typing.Iterator[str]:
+        if isinstance(part, TypeName):
+            yield from part.parts
+        elif isinstance(part, VariableName):
+            yield str(part)
+        elif isinstance(part, str):
+            if part == ".":
+                yield part
+            else:
+                yield from parser.parse_typeName(part).parts
+        else:
+            raise TypeError(
+                f"Unexpected part, got {part}: {type(part)}"
+            )
+
     @classmethod
     def __from_valid_parts_no_check__(
         cls,
@@ -181,37 +212,6 @@ class TypeName(
             return parent
         else:
             return self
-
-    @staticmethod
-    def __split_part(
-        part,
-    ) -> typing.Iterator[str]:
-        if isinstance(part, TypeName):
-            yield from part.parts
-        elif isinstance(part, VariableName):
-            yield str(part)
-        elif isinstance(part, str):
-            if part == ".":
-                yield part
-            else:
-                yield from parser.parse_typeName(part).parts
-        else:
-            raise TypeError(
-                f"Unexpected part, got {part}: {type(part)}"
-            )
-
-    @staticmethod
-    def __split_parts(
-        parts,
-    ) -> typing.Iterator[str]:
-        for i, part in enumerate(
-            itertools.chain(*map(TypeName.__split_part, parts))
-        ):
-            if part == "." and not i == 0:
-                raise ValueError(
-                    f"parts[{i}] is invalid, got {part!r}"
-                )
-            yield part
 
     def __hash__(self):
         return hash(self.parts)

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -882,8 +882,11 @@ class ModelicaEnumeration(
 ):
     __modelica_name__: typing.ClassVar[TypeName]
 
+    def __as_typeName__(self) -> TypeName:
+        return self.__modelica_name__/self.name
+
     def __str__(self) -> str:
-        return str(self.__modelica_name__/self.name)
+        return str(self.__as_typeName__())
 
     __to_omc_literal__ = __str__
 

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -129,7 +129,7 @@ class TypeName(
                 return part
 
         return cls.__from_valid_parts_no_check__(
-            cls.__checked_parts(
+            cls.__split_parts(
                 (part, *parts)
             )
         )
@@ -182,30 +182,30 @@ class TypeName(
         else:
             return self
 
-    @classmethod
-    def __checked_parts(
-        cls,
-        parts: typing.Iterable,
-    ) -> typing.Iterator[typing.Union[str, VariableName]]:
-        def split_part(
-            part
-        ) -> typing.Iterator[str]:
-            if isinstance(part, TypeName):
-                yield from part.parts
-            elif isinstance(part, VariableName):
-                yield str(part)
-            elif isinstance(part, str):
-                if part == ".":
-                    yield part
-                else:
-                    yield from parser.parse_typeName(part).parts
+    @staticmethod
+    def __split_part(
+        part,
+    ) -> typing.Iterator[str]:
+        if isinstance(part, TypeName):
+            yield from part.parts
+        elif isinstance(part, VariableName):
+            yield str(part)
+        elif isinstance(part, str):
+            if part == ".":
+                yield part
             else:
-                raise TypeError(
-                    f"Unexpected part, got {part}: {type(part)}"
-                )
+                yield from parser.parse_typeName(part).parts
+        else:
+            raise TypeError(
+                f"Unexpected part, got {part}: {type(part)}"
+            )
 
+    @staticmethod
+    def __split_parts(
+        parts,
+    ) -> typing.Iterator[str]:
         for i, part in enumerate(
-            itertools.chain(*map(split_part, parts))
+            itertools.chain(*map(TypeName.__split_part, parts))
         ):
             if part == "." and not i == 0:
                 raise ValueError(

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -35,6 +35,8 @@ VariableNameLike = typing.Union[
 ]
 
 TypeNameLike = typing.Union[
+    "ModelicaClassMeta",
+    "ModelicaEnumeration",
     VariableNameLike,
 ]
 
@@ -170,7 +172,11 @@ class TypeName(
     def __split_part(
         part: TypeNameLike,
     ) -> typing.Iterator[str]:
-        if isinstance(part, TypeName):
+        if isinstance(part, ModelicaClassMeta):
+            yield from part.__modelica_name__.parts
+        elif isinstance(part, ModelicaEnumeration):
+            yield from part.__as_typeName__().parts
+        elif isinstance(part, TypeName):
             yield from part.parts
         elif isinstance(part, VariableName):
             yield str(part)
@@ -696,9 +702,14 @@ class Component(
         elif self.class_ is String:
             return tuple({String, str})
         elif self.class_ is TypeName:
-            return tuple({TypeName, VariableName, str})  # TypeNameLike
+            return tuple({
+                ModelicaClassMeta, ModelicaEnumeration,
+                TypeName, VariableName, str,
+            })  # TypeNameLike
         elif self.class_ is VariableName:
-            return tuple({TypeName, VariableName, str})  # VariableNameLike
+            return tuple({
+                TypeName, VariableName, str,
+            })  # VariableNameLike
         else:
             return ()
 

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -31,7 +31,11 @@ REQUIRED_or_OPTIONAL = typing.Union[REQUIRED, OPTIONAL]
 VariableNameLike = typing.Union[
     "TypeName",
     "VariableName",
-    "str"
+    str,
+]
+
+TypeNameLike = typing.Union[
+    VariableNameLike,
 ]
 
 InputArgument = typing.Tuple[
@@ -151,7 +155,7 @@ class TypeName(
 
     @staticmethod
     def __split_parts(
-        parts,
+        parts: typing.Iterable[TypeNameLike],
     ) -> typing.Iterator[str]:
         for i, part in enumerate(
             itertools.chain(*map(TypeName.__split_part, parts))
@@ -164,7 +168,7 @@ class TypeName(
 
     @staticmethod
     def __split_part(
-        part,
+        part: TypeNameLike,
     ) -> typing.Iterator[str]:
         if isinstance(part, TypeName):
             yield from part.parts
@@ -692,7 +696,7 @@ class Component(
         elif self.class_ is String:
             return tuple({String, str})
         elif self.class_ is TypeName:
-            return tuple({TypeName, str})
+            return tuple({TypeName, VariableName, str})  # TypeNameLike
         elif self.class_ is VariableName:
             return tuple({TypeName, VariableName, str})  # VariableNameLike
         else:

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -135,13 +135,6 @@ class TypeName(
         )
 
     @classmethod
-    def from_str(
-        cls,
-        s: str
-    ) -> "TypeName":
-        return parser.parse_typeName(s)
-
-    @classmethod
     def __from_valid_parts_no_check__(
         cls,
         parts: typing.Iterable[str],
@@ -205,7 +198,7 @@ class TypeName(
                 if part == ".":
                     yield part
                 else:
-                    yield from split_part(cls.from_str(part))
+                    yield from parser.parse_typeName(part).parts
             else:
                 raise TypeError(
                     f"Unexpected part, got {part}: {type(part)}"


### PR DESCRIPTION
# VariableName-like

Objects that can be casted to `omc4.py.classes.VariableName`

- `omc4py.classes.TypeName`
- `omc4py.classes.VariableName`
- `omc4py.classes.str`

# TypeName-like

Objects that can be casted to `omc4.py.classes.TypeName`

- `omc4py.classes.ModelicaClassMeta` [^1]
- `omc4py.classes.ModelicaEnumeration` [^2]
- `omc4py.classes.TypeName`
- `omc4py.classes.VariableName`
- `omc4py.classes.str`

[^1]:
modelica-class object (s.t. `OpenModelica.Scripiting`) is instance of `ModelicaClassMeta` in omc4py.

[^2]:
Modelica's enumeraion literal syntax is same as `OpenModelica.$Code.TypeName` syntax. So that `ModelicaEnumeration` and `TypeName` can be converted to each other.