### PR TITLE
Refactor/variable name visitor

### DIFF
--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -115,18 +115,9 @@ class VariableName(
                 f"Invalid modelica identifier, got {identifier!r}"
             )
 
-        return cls.__from_valid_identifier_no_check__(
-            identifier
+        return _VariableName_from_valid_identifier_no_check(
+            cls, identifier
         )
-
-    @classmethod
-    def __from_valid_identifier_no_check__(
-        cls,
-        identifier: str
-    ) -> "VariableName":
-        variableName = object.__new__(cls)
-        variableName.__str = identifier
-        return variableName
 
     def __eq__(
         self, other,
@@ -171,8 +162,9 @@ class VariableNameVisitor(
         node,
         children,
     ) -> VariableName:
-        return VariableName.__from_valid_identifier_no_check__(
-            node.value
+        return _VariableName_from_valid_identifier_no_check(
+            VariableName,
+            str(node.value)
         )
 
 

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -154,6 +154,15 @@ class VariableName(
     __to_omc_literal__ = __str__
 
 
+def _VariableName_from_valid_identifier_no_check(
+    cls: typing.Type[VariableName],
+    identifier: str,
+) -> VariableName:
+    variableName = super(cls, VariableName).__new__(cls)
+    variableName._VariableName__str = identifier
+    return variableName
+
+
 class VariableNameVisitor(
     arpeggio.PTNodeVisitor,
 ):

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -26,6 +26,7 @@ __all__ = (
 )
 
 import abc
+import arpeggio  # type: ignore
 import enum
 import itertools
 import functools
@@ -151,6 +152,19 @@ class VariableName(
         return f"{type(self).__name__}({str(self)!r})"
 
     __to_omc_literal__ = __str__
+
+
+class VariableNameVisitor(
+    arpeggio.PTNodeVisitor,
+):
+    def visit_IDENT(
+        self,
+        node,
+        children,
+    ) -> VariableName:
+        return VariableName.__from_valid_identifier_no_check__(
+            node.value
+        )
 
 
 class TypeName(

--- a/omc4py/parser/visitor.py
+++ b/omc4py/parser/visitor.py
@@ -44,7 +44,7 @@ def getitem_with_default(
             raise
 
 
-class TypeSpecifierVisitor(
+class VariableNameVisitor(
     arpeggio.PTNodeVisitor,
 ):
     def visit_IDENT(
@@ -56,6 +56,10 @@ class TypeSpecifierVisitor(
             node.value
         )
 
+
+class TypeSpecifierVisitor(
+    VariableNameVisitor,
+):
     def visit_name(
         self,
         node,

--- a/omc4py/parser/visitor.py
+++ b/omc4py/parser/visitor.py
@@ -10,6 +10,7 @@ from omc4py.classes import (
     Real,
     TypeName,
     VariableName,
+    VariableNameVisitor,
 )
 
 from omc4py import string
@@ -42,19 +43,6 @@ def getitem_with_default(
             return default
         else:
             raise
-
-
-class VariableNameVisitor(
-    arpeggio.PTNodeVisitor,
-):
-    def visit_IDENT(
-        self,
-        node,
-        children,
-    ) -> VariableName:
-        return VariableName.__from_valid_identifier_no_check__(
-            node.value
-        )
 
 
 class TypeSpecifierVisitor(


### PR DESCRIPTION
Hide un-safe VariableName constructor from classmethod to private module function (not contained in module's `__all__`).

And, move `VariableNameVisitor` uses private module function to correct module.
