### PR TITLE
Refactor/enumeration

### DIFF
--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -924,6 +924,9 @@ class ModelicaEnumeration(
 ):
     __modelica_name__: typing.ClassVar[TypeName]
 
+    def _generate_next_value_(name, start, count, last_values):
+        return Integer(count + 1)
+
     def __as_typeName__(self) -> TypeName:
         return self.__modelica_name__/self.name
 

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -919,7 +919,6 @@ class external(
 # base classes for modelica-like class
 
 class ModelicaEnumeration(
-    Integer,
     enum.Enum,
     metaclass=ModelicaEnumerationMeta,
 ):

--- a/omc4py/classes.py
+++ b/omc4py/classes.py
@@ -57,6 +57,11 @@ TypeNameLike = typing.Union[
     VariableNameLike,
 ]
 
+EnumerationLike = typing.Union[
+    "ModelicaEnumerationMeta",
+    "TypeName",
+]
+
 InputArgument = typing.Tuple[
     "Component", str,
     typing.Any, REQUIRED_or_OPTIONAL
@@ -395,9 +400,7 @@ class ModelicaEnumerationMeta(
                     f"value: TypeName must be {cls.__modelica_name__}.* "
                     f"got {value!s}"
                 )
-            return cls(str(value.last_identifier))
-        elif isinstance(value, str):
-            return cls[value]
+            return cls[str(value.last_identifier)]
         else:
             return super().__call__(value)
 
@@ -741,6 +744,10 @@ class Component(
         elif self.class_ is VariableName:
             return (  # VariableNameLike
                 TypeName, VariableName, str,
+            )
+        elif issubclass(self.class_, ModelicaEnumeration):
+            return (  # EnumerationLike
+                self.class_, TypeName,
             )
         else:
             return ()


### PR DESCRIPTION
Stop loose ModelicaEnumeration constructor check

Now, `ModelicaEnumeration.__new__` only accepts enumeration object itself or `omc4py.classes.TypeName`
