### PR TITLE
Refactor/call_function error check

### DIFF
--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -9,12 +9,15 @@ import tempfile
 import typing
 import typing_extensions
 import uuid
+import warnings
 import zmq  # type: ignore
 
 from . import (
     classes,
     string,
 )
+
+from .parser import parse_OMCExceptions
 
 
 logger = logging.getLogger(__name__)
@@ -247,9 +250,11 @@ class OMCInteractive(
         try:
             result_value = parser(result_literal)
         except Exception:
-            raise ValueError(
-                f"Failed to parse {result_literal!r}"
-            ) from None
+            for exc in parse_OMCExceptions(result_literal):
+                if isinstance(exc, Warning):
+                    warnings.warn(exc)
+                else:
+                    raise exc from None
 
         if len(outputArguments) == 0:
             raise ValueError(

--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -240,13 +240,9 @@ class OMCInteractive(
             )
         )
 
+        # return None if result_literal == "\n"
         if not result_literal or result_literal.isspace():
-            if outputArguments:
-                raise ValueError(
-                    f"Unexpected empty result, got {result_literal!r}"
-                )
-            else:
-                return None
+            return None
 
         try:
             result_value = parser(result_literal)
@@ -260,7 +256,7 @@ class OMCInteractive(
                 "There is no output variable in the function, "
                 f"but omc returns {result_value!r}"
             )
-        if len(outputArguments) == 1:
+        elif len(outputArguments) == 1:
             (component, name,), = outputArguments
             return component.cast(name, result_value)
         else:

--- a/omc4py/exception.py
+++ b/omc4py/exception.py
@@ -6,6 +6,16 @@ __all__ = (
     "OMCWarning",
 )
 
+import typing
+import warnings
+
+
+def warn_always(
+    warning_type: typing.Type[Warning],
+) -> typing.Type[Warning]:
+    warnings.simplefilter("always", warning_type)
+    return warning_type
+
 
 class OMCException(
     Exception,
@@ -13,6 +23,7 @@ class OMCException(
     ...
 
 
+@warn_always
 class OMCNotification(
     OMCException,
     Warning,
@@ -20,6 +31,7 @@ class OMCNotification(
     ...
 
 
+@warn_always
 class OMCWarning(
     OMCException,
     Warning,

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -66,7 +66,7 @@ def get_omc_value_parser() -> arpeggio.Parser:
 @functools.lru_cache(1)
 def get_omc_error_regex():
     return re.compile(
-        r"(\[(?P<info>[^]]*)\]\s+)?(?P<kind>\w+):\s+(?P<message>.*)"
+        r"(\[(?P<info>[^]]*)\]\s+)?(?P<level>\w+):\s+(?P<message>.*)"
     )
 
 
@@ -135,10 +135,10 @@ def parse_OMCError(
             f"Unexpected error message format: {error_string!r}"
         )
     # info = matched.group("info")
-    kind = matched.group("kind")
+    level = matched.group("level").lower()
     # message = matched.group("message")
 
-    if kind.lower() == "error":
+    if level == "error":
         return exception.OMCError(error_string)
     else:
         return exception.OMCWarning(error_string)

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -64,7 +64,7 @@ def get_omc_value_parser() -> arpeggio.Parser:
 
 
 @functools.lru_cache(1)
-def get_omc_error_regex():
+def get_omc_exception_regex():
     return re.compile(
         (
             r"(\[(?P<info>[^]]*)\]\s+)?"
@@ -129,7 +129,7 @@ def parse_OMCValue__v_1_13(
 def parse_OMCExceptions(
     error_string: str,
 ) -> typing.Iterator[exception.OMCException]:
-    for matched in get_omc_error_regex().finditer(error_string):
+    for matched in get_omc_exception_regex().finditer(error_string):
         level = matched.group("level").lower()
         message = matched.group("message")
 

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -66,7 +66,11 @@ def get_omc_value_parser() -> arpeggio.Parser:
 @functools.lru_cache(1)
 def get_omc_error_regex():
     return re.compile(
-        r"(\[(?P<info>[^]]*)\]\s+)?(?P<level>\w+):\s+(?P<message>((?!$).)*)$",
+        (
+            r"(\[(?P<info>[^]]*)\]\s+)?"
+            r"(?P<level>\w+):\s+"
+            r"(?P<message>((?!$).)*)$"
+        ),
         re.MULTILINE,
     )
 

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -141,13 +141,13 @@ def parse_OMCError(
         )
     # info = matched.group("info")
     level = matched.group("level").lower()
-    # message = matched.group("message")
+    message = matched.group("message")
 
     if level == "notification":
-        return exception.OMCNotification(error_string)
+        return exception.OMCNotification(message)
     elif level == "warning":
-        return exception.OMCWarning(error_string)
+        return exception.OMCWarning(message)
     elif level == "error":
-        return exception.OMCError(error_string)
+        return exception.OMCError(message)
     else:  # Not-implemented now, but valid level (for future)
-        return exception.OMCError(error_string)
+        return exception.OMCError(message)

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -138,7 +138,11 @@ def parse_OMCError(
     level = matched.group("level").lower()
     # message = matched.group("message")
 
-    if level == "error":
-        return exception.OMCError(error_string)
-    else:
+    if level == "notification":
+        return exception.OMCNotification(error_string)
+    elif level == "warning":
         return exception.OMCWarning(error_string)
+    elif level == "error":
+        return exception.OMCError(error_string)
+    else:  # Not-implemented now, but valid level (for future)
+        return exception.OMCError(error_string)

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -66,7 +66,8 @@ def get_omc_value_parser() -> arpeggio.Parser:
 @functools.lru_cache(1)
 def get_omc_error_regex():
     return re.compile(
-        r"(\[(?P<info>[^]]*)\]\s+)?(?P<level>\w+):\s+(?P<message>.*)"
+        r"(\[(?P<info>[^]]*)\]\s+)?(?P<level>\w+):\s+(?P<message>((?!$).)*)$",
+        re.MULTILINE,
     )
 
 

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -2,7 +2,7 @@
 __all__ = (
     "ComponentTuple",
     "is_valid_identifier",
-    "parse_OMCError",
+    "parse_OMCExceptions",
     "parse_OMCValue",
     "parse_typeName",
     "parse_components",
@@ -124,33 +124,6 @@ def parse_OMCValue__v_1_13(
         get_omc_value_parser().parse(literal),
         visitor.OMCValueVisitor__v_1_13(),
     )
-
-
-def parse_OMCError(
-    error_string: str,
-) -> typing.Optional[exception.OMCException]:
-    if not error_string or error_string.isspace():
-        return None
-
-    matched = get_omc_error_regex().match(
-        error_string
-    )
-    if not matched:
-        raise exception.OMCRuntimeError(
-            f"Unexpected error message format: {error_string!r}"
-        )
-    # info = matched.group("info")
-    level = matched.group("level").lower()
-    message = matched.group("message")
-
-    if level == "notification":
-        return exception.OMCNotification(message)
-    elif level == "warning":
-        return exception.OMCWarning(message)
-    elif level == "error":
-        return exception.OMCError(message)
-    else:  # Not-implemented now, but valid level (for future)
-        return exception.OMCError(message)
 
 
 def parse_OMCExceptions(

--- a/omc4py/parser/__init__.py
+++ b/omc4py/parser/__init__.py
@@ -151,3 +151,20 @@ def parse_OMCError(
         return exception.OMCError(message)
     else:  # Not-implemented now, but valid level (for future)
         return exception.OMCError(message)
+
+
+def parse_OMCExceptions(
+    error_string: str,
+) -> typing.Iterator[exception.OMCException]:
+    for matched in get_omc_error_regex().finditer(error_string):
+        level = matched.group("level").lower()
+        message = matched.group("message")
+
+        if level == "notification":
+            yield exception.OMCNotification(message)
+        elif level == "warning":
+            yield exception.OMCWarning(message)
+        elif level == "error":
+            yield exception.OMCError(message)
+        else:  # Not-implemented now, but valid level (for future)
+            yield exception.OMCError(message)

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -16,7 +16,7 @@ from .classes import (
 )
 from .parser import (
     ComponentTuple,
-    parse_OMCError,
+    parse_OMCExceptions,
     parse_OMCValue,
     parse_components,
 )
@@ -77,15 +77,11 @@ class OMCSessionMinimal(
     def __check__(
         self,
     ) -> None:
-        for errorString in self.getErrorString().splitlines():
-            error = parse_OMCError(errorString)
-            if error is None:
-                return
-
-            if isinstance(error, Warning):
-                warnings.warn(error)
+        for exc in parse_OMCExceptions(self.getErrorString()):
+            if isinstance(exc, Warning):
+                warnings.warn(exc)
             else:
-                raise error
+                raise exc
 
     def getErrorString(
         self,

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -1,6 +1,5 @@
 
 import abc
-import functools
 import re
 import typing
 import warnings
@@ -17,6 +16,7 @@ from .classes import (
 )
 from .parser import (
     ComponentTuple,
+    parse_OMCError,
     parse_OMCValue,
     parse_components,
 )
@@ -69,36 +69,6 @@ class OMCSessionBase__v_1_13(
                 raise exception.OMCRuntimeError(
                     f"Unexpected message level, got {level}"
                 )
-
-
-@functools.lru_cache(1)
-def get_omc_error_regex():
-    return re.compile(
-        r"(\[(?P<info>[^]]*)\]\s+)?(?P<kind>\w+):\s+(?P<message>.*)"
-    )
-
-
-def parse_OMCError(
-    error_string: str,
-) -> typing.Optional[exception.OMCException]:
-    if not error_string or error_string.isspace():
-        return None
-
-    matched = get_omc_error_regex().match(
-        error_string
-    )
-    if not matched:
-        raise exception.OMCRuntimeError(
-            f"Unexpected error message format: {error_string!r}"
-        )
-    # info = matched.group("info")
-    kind = matched.group("kind")
-    # message = matched.group("message")
-
-    if kind.lower() == "error":
-        return exception.OMCError(error_string)
-    else:
-        return exception.OMCWarning(error_string)
 
 
 class OMCSessionMinimal(


### PR DESCRIPTION
Refactor omc error conversion.

- Change to warning filter `omc4py.exception.OMCWarning`, `omc4py.exception.OMCNotification` from default to always
- Since _OpenModelica.Scripting.getErrorString_ returns zero or more exception at one-time, update omc error parser to return `omc4py.exception.OMCException` iterator