### PR TITLE
Refactor/get components error

### DIFF
--- a/omc4py/compiler.py
+++ b/omc4py/compiler.py
@@ -255,7 +255,7 @@ class OMCInteractive(
             if not excs:
                 raise exception.OMCRuntimeError(
                     result_literal
-                )
+                ) from None
             else:
                 for exc in excs:
                     if isinstance(exc, Warning):

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -96,7 +96,7 @@ class OMCSessionBase(
             if not excs:
                 raise exception.OMCRuntimeError(
                     result_literal
-                )
+                ) from None
             else:
                 for exc in excs:
                     if isinstance(exc, Warning):

--- a/omc4py/session.py
+++ b/omc4py/session.py
@@ -156,6 +156,14 @@ class OMCSessionMinimal(
             else:
                 raise exc
 
+    def getComponents(
+        self,
+        name: TypeName
+    ) -> typing.Optional[typing.List[ComponentTuple]]:
+        result = super().getComponents(name)
+        self.__check__()
+        return result
+
     def getErrorString(
         self,
     ) -> str:


### PR DESCRIPTION
Update erorr-handling of `omc4py.session.OMCSessionBase.getComponents` as `omc4py.compiler.OMCInteractive.call_function`