### PR TITLE
Fix/supported element

### DIFF
--- a/omc4py/v_1_14/_omc_interface.py
+++ b/omc4py/v_1_14/_omc_interface.py
@@ -11212,40 +11212,40 @@ end oms_getVariableStepSize;
                     parser=parse_OMCValue,
                 )
 
-        @modelica_name('OpenModelica.Scripting.oms_faultInjection')
-        class oms_faultInjection(
-            ModelicaFunction,
-        ):
-            """
-```modelica
-function oms_faultInjection
-  input String signal;
-  input oms_fault_type_enu_t faultType;
-  input Real faultValue;
-  output Integer status;
-end oms_faultInjection;
-```
-            """
-            @external
-            def _(
-                _cls_,
-                _session_: AbstractOMCSession,
-                signal,
-                faultType,
-                faultValue,
-            ):
-                return _session_.__omc__.call_function(
-                    funcName='oms_faultInjection',
-                    inputArguments=[
-                        (Component(String),'signal',signal,'required'),
-                        (Component(oms_fault_type_enu_t),'faultType',faultType,'required'),
-                        (Component(Real),'faultValue',faultValue,'required'),
-                    ],
-                    outputArguments=[
-                        (Component(Integer),'status'),
-                    ],
-                    parser=parse_OMCValue,
-                )
+        # @modelica_name('OpenModelica.Scripting.oms_faultInjection')
+        # class oms_faultInjection(
+        #     ModelicaFunction,
+        # ):
+        #     """
+        # ```modelica
+        # function oms_faultInjection
+        #   input String signal;
+        #   input oms_fault_type_enu_t faultType;
+        #   input Real faultValue;
+        #   output Integer status;
+        # end oms_faultInjection;
+        # ```
+        #     """
+        #     @external
+        #     def _(
+        #         _cls_,
+        #         _session_: AbstractOMCSession,
+        #         signal,
+        #         faultType,
+        #         faultValue,
+        #     ):
+        #         return _session_.__omc__.call_function(
+        #             funcName='oms_faultInjection',
+        #             inputArguments=[
+        #                 (Component(String),'signal',signal,'required'),
+        #                 (Component(oms_fault_type_enu_t),'faultType',faultType,'required'),
+        #                 (Component(Real),'faultValue',faultValue,'required'),
+        #             ],
+        #             outputArguments=[
+        #                 (Component(Integer),'status'),
+        #             ],
+        #             parser=parse_OMCValue,
+        #         )
 
         @modelica_name('OpenModelica.Scripting.oms_importFile')
         class oms_importFile(
@@ -12835,7 +12835,7 @@ class OMCSession(
     oms_getSystemType = OpenModelica.Scripting.oms_getSystemType
     oms_getTolerance = OpenModelica.Scripting.oms_getTolerance
     oms_getVariableStepSize = OpenModelica.Scripting.oms_getVariableStepSize
-    oms_faultInjection = OpenModelica.Scripting.oms_faultInjection
+    # oms_faultInjection = OpenModelica.Scripting.oms_faultInjection
     oms_importFile = OpenModelica.Scripting.oms_importFile
     oms_initialize = OpenModelica.Scripting.oms_initialize
     oms_instantiate = OpenModelica.Scripting.oms_instantiate


### PR DESCRIPTION
# Problem

In omc v1.14.x, _OpenModelica.Scripting.oms_faultInjection_ is not callable from omc.

_oms_faultInjection_ is added to omc from v1.14.0 (omc before v1.14.x does not implement this feature).

__Correct__ signature is shown below
```modelica
OMShell Copyright 1997-2020, Open Source Modelica Consortium (OSMC)
Distributed under OMSC-PL and GPL, see www.openmodelica.org

To get help on using OMShell and OpenModelica, type "help()" and press enter
Set shortOutput flag: true

>>> getVersion()
"OpenModelica 1.16.0~dev-564-g9890278"

>>> list(OpenModelica.Scripting.oms_faultInjection, interfaceOnly=true)
"function oms_faultInjection
  input String signal;
  input oms_fault_type faultType;
  input Real faultValue;
  output Integer status;
end oms_faultInjection;"

>>> isEnumeration(OpenModelica.Scripting.oms_fault_type)
true

>>> list(OpenModelica.Scripting.oms_fault_type)
"type oms_fault_type = enumeration(oms_fault_type_bias, oms_fault_type_gain, oms_fault_type_const);"
>>>
```

However, in omc v1.14.0, type of second argument is `oms_fault_type_enu_t`. `oms_fault_type_enu_t` is not visible from omc.
```modelica
OMShell Copyright 1997-2020, Open Source Modelica Consortium (OSMC)
Distributed under OMSC-PL and GPL, see www.openmodelica.org

To get help on using OMShell and OpenModelica, type "help()" and press enter
Set shortOutput flag: true

>>> getVersion()
"OMCompiler v1.14.0"

>>> list(OpenModelica.Scripting.oms_faultInjection, interfaceOnly=true)
"function oms_faultInjection
  input String signal;
  input oms_fault_type_enu_t faultType;
  input Real faultValue;
  output Integer status;
end oms_faultInjection;"

>>> isEnumeration(OpenModelica.Scripting.oms_fault_enu_t)
false

>>> list(OpenModelica.Scripting.oms_fault_type_enu_t)
""

>>> isEnumeration(oms_fault_enu_t)
false

>>> list(oms_fault_type_enu_t)
""

>>>
```

Thus, interactive session bind to omc v1.14.0 can't call `oms_faultInjection`. And must not exported to `omc4py.v_1_14`

# Solution

Add check for all type of component  in _record_ or _function_ is supported.
